### PR TITLE
feat: add landlock glob pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,7 +998,7 @@ checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "rootasrole"
-version = "3.3.1"
+version = "3.3.2"
 dependencies = [
  "bitflags 2.9.3",
  "bon",
@@ -1008,6 +1008,7 @@ dependencies = [
  "const_format",
  "derivative",
  "env_logger",
+ "glob",
  "hex",
  "landlock",
  "libc",
@@ -1035,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "rootasrole-core"
-version = "3.3.1"
+version = "3.3.2"
 dependencies = [
  "bitflags 2.9.3",
  "bon",
@@ -1758,7 +1759,7 @@ checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
 
 [[package]]
 name = "xtask"
-version = "3.3.1"
+version = "3.3.2"
 dependencies = [
  "anyhow",
  "capctl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["xtask", "rar-common"]
 
 [package]
 name = "rootasrole"
-version = "3.3.1"
+version = "3.3.2"
 rust-version = "1.83.0"
 authors = ["Eddie Billoir <lechatp@outlook.fr>"]
 edition = "2021"
@@ -59,7 +59,7 @@ hashchecker = ["dep:hex", "dep:sha2"]
 ssd = []
 hierarchy = []
 timeout = []
-landlock = ["dep:landlock", "dep:bitflags"]
+landlock = ["dep:landlock", "dep:bitflags", "dep:glob"]
 editor = ["dep:landlock", "dep:libseccomp", "dep:pest", "dep:pest_derive", "dep:linked_hash_set"]
 
 [lints.rust]
@@ -69,7 +69,7 @@ unexpected_cfgs = { level = "allow", check-cfg = ['cfg(tarpaulin_include)'] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display", "preserve_order"] }
 
 [dependencies]
-rar-common = { path = "rar-common", version = "3.3.1", package = "rootasrole-core" }
+rar-common = { path = "rar-common", version = "3.3.2", package = "rootasrole-core" }
 log = { version = "0.4", default-features = false, features = ["std"] }
 libc = { version = "0.2", default-features = false, features = ["std"]}
 strum = { version = "0.26", default-features = false, features = ["derive"] }
@@ -87,6 +87,7 @@ bon = { version = "3", default-features = false }
 nonstick = { version = "0.1.1", optional = true }
 libpam-sys = { version = "0.2.0", default-features = false, optional = true }
 pcre2 = { version = "0.2", default-features = false, optional = true }
+glob = { version = "0.3", default-features = false, optional = true }
 sha2 = { version = "0.10", default-features = false, optional = true }
 pty-process = { version = "0.4", default-features = false, optional = true }
 once_cell = { version = "1.20", default-features = false, optional = true, features = ["std"] }

--- a/rar-common/Cargo.toml
+++ b/rar-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rootasrole-core"
-version = "3.3.1"
+version = "3.3.2"
 edition = "2021"
 description = "This core crate for the RootAsRole project."
 license = "LGPL-3.0-or-later"

--- a/resources/man/en_US.md
+++ b/resources/man/en_US.md
@@ -1,4 +1,4 @@
-% RootAsRole(8) RootAsRole 3.3.1 | System Manager's Manual
+% RootAsRole(8) RootAsRole 3.3.2 | System Manager's Manual
 % Eddie Billoir <lechatp@outlook.fr>
 % August 2025
 

--- a/resources/man/fr_FR.md
+++ b/resources/man/fr_FR.md
@@ -1,4 +1,4 @@
-% RootAsRole(8) RootAsRole 3.3.1 | Manuel de l'administrateur système
+% RootAsRole(8) RootAsRole 3.3.2 | Manuel de l'administrateur système
 % Eddie Billoir <lechatp@outlook.fr>
 % Août 2025
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xtask"
 # The project version is managed on json file in resources/rootasrole.json
-version = "3.3.1"
+version = "3.3.2"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
This pull request updates the project version to 3.3.2 throughout the codebase and introduces support for glob patterns in Landlock whitelist paths. The most significant functional change is the addition of the `glob` crate and its integration into the Landlock API, allowing path patterns in whitelists to be expanded automatically.

**Landlock feature improvements:**

* Add the `glob` crate as an optional dependency and include it in the `landlock` feature group in `Cargo.toml`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L62-R62) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R90)
* Import the `glob` crate in `src/sr/finder/api/landlock.rs` to enable globbing functionality for path whitelists.
* Update the Landlock API to support glob patterns in whitelist paths: when a whitelist entry contains a glob pattern, all matching paths are added as rules; if glob expansion fails, the original path is used as a fallback.